### PR TITLE
Add aeryn.ts to invite new members

### DIFF
--- a/org/aeryn.ts
+++ b/org/aeryn.ts
@@ -1,0 +1,47 @@
+// For the inspiration for this file, see: https://github.com/danger/peril-settings/blob/fc0015452438c8a1624c0951a600f723f2e60fea/org/aeryn.ts#L18-L39
+import { schedule, danger, markdown } from "danger"
+
+// Hey there!
+//
+// When a PR is closed, this file gets run. The purpose of this file is to 
+// replicate Aeryn (https://github.com/Moya/Aeryn), which invites new 
+// contributors to join the organization after their first PR gets merged.
+//
+// Ignore the next four const lines.
+// The inspiration for this is https://github.com/artsy/artsy-danger/blob/f019ee1a3abffabad65014afabe07cb9a12274e7/org/all-prs.ts
+const isJest = typeof jest !== "undefined"
+// Returns the promise itself, for testing.
+const _test = (reason: string, promise: Promise<any>) => promise
+// Schedules the promise for execution via Danger.
+const _run = (reason: string, promise: Promise<any>) => schedule(promise)
+const wrap: any = isJest ? _test : _run
+
+export const aeryn = wrap("When a PR is merged, check if the author is in the org", async () => {
+  const pr = danger.github.pr
+  const username = pr.user.login
+  const api = danger.github.api
+
+  if (!pr.merged) {
+    // Only proceed if the PR was merged (as opposed to closed without merging).
+    return
+  }
+
+  const org = "ReSwift"
+  const inviteMarkdown = `
+  @${username} Thanks a lot for contributing to ReSwift! We've invited you to join 
+  the ReSwift GitHub organization – no pressure to accept! If you'd like more 
+  information on what that means, check out our [contributor guidelines][c].
+
+  [c]: https://github.com/ReSwift/ReSwift/blob/master/CONTRIBUTING.md
+  `
+
+  try {
+    // This throws if the user isn't a member of the org yet. If it doesn't
+    // throw, then it means the user was already invited or has already 
+    // accepted the invitation (we ignore the return value here).
+    await api.orgs.checkMembership({ org, username })
+  } catch (error) {
+    markdown(inviteMarkdown)
+    await api.orgs.addOrgMembership({ org, username, role: "member" })
+  }
+})


### PR DESCRIPTION
### Related Issues:
https://github.com/ReSwift/ReSwift/issues/339

### Summary of PR:
Adds a new peril rule to automatically invite new members to the ReSwift organization on a merged PR.

The following is an example of the message that will be sent to new users. You can get a better visual of the message [here at Moya](https://github.com/Moya/Moya/pull/1640#issuecomment-381720452).

cc @Ben-G, 
if this message is acceptable to you I will merge and restart the peril server for it to take effect

```typescript
const inviteMarkdown = `
@${username} Thanks a lot for contributing to ReSwift! We've invited you to join 
the ReSwift GitHub organization – no pressure to accept! If you'd like more 
information on what that means, check out our [contributor guidelines][c].

[c]: https://github.com/ReSwift/ReSwift/blob/master/CONTRIBUTING.md
`
```